### PR TITLE
[FEAT] ErrorMessage 기능 구현 

### DIFF
--- a/src/main/java/com/example/baro/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/baro/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,60 @@
+package com.example.baro.common.exception;
+
+
+import com.example.baro.common.exception.dto.ErrorResponse;
+import com.example.baro.common.exception.dto.ValidationErrorResponse;
+import com.example.baro.common.exception.exceptionClass.CustomException;
+import com.example.baro.common.exception.properties.ErrorCode;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    // 사용자 정의 에러를 보여주는 함수
+    @ExceptionHandler(value = {CustomException.class})
+    protected ResponseEntity<ErrorResponse> handleCustomException(
+            CustomException e, HttpServletRequest request
+    ) {
+        return ErrorResponse.toResponseEntity(e.getErrorCode(), e.getRuntimeValue());
+    }
+
+    // 바인딩, 검증 에러를 보여주는 함수
+    @ExceptionHandler(value = {
+            BindException.class,
+            MethodArgumentNotValidException.class
+    })
+    protected ResponseEntity<List<ValidationErrorResponse>> validationException(BindException e,
+                                                                                HttpServletRequest request) {
+        BindingResult bindingResult = e.getBindingResult();
+        List<ValidationErrorResponse> errors = new ArrayList<>();
+        for (FieldError fieldError : bindingResult.getFieldErrors()) {
+            ValidationErrorResponse error = new ValidationErrorResponse(
+                    fieldError.getField(),
+                    fieldError.getDefaultMessage(),
+                    fieldError.getRejectedValue()
+            );
+            errors.add(error);
+        }
+        return ResponseEntity.badRequest().body(errors);
+    }
+
+    // 이외에 기타 에러(500)를 보여주는 함수
+    @ExceptionHandler(value = Exception.class)
+    protected ResponseEntity<ErrorResponse> handleException(
+            Exception e, HttpServletRequest request
+    ) {
+        return ErrorResponse.toResponseEntity(ErrorCode.SERVER_ERROR, e.getMessage());
+    }
+}

--- a/src/main/java/com/example/baro/common/exception/dto/ErrorResponse.java
+++ b/src/main/java/com/example/baro/common/exception/dto/ErrorResponse.java
@@ -1,0 +1,34 @@
+package com.example.baro.common.exception.dto;
+
+import com.example.baro.common.exception.properties.ErrorCode;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.ResponseEntity;
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class ErrorResponse {
+
+    private final LocalDateTime timestamp = LocalDateTime.now();
+    private final int statusCode;
+    private final String statusCodeName;
+    private final String code;
+    private final String message;
+    private final String runtimeValue;
+
+    public static ResponseEntity<ErrorResponse> toResponseEntity(
+            ErrorCode errorCode, String runtimeValue
+    ) {
+        return ResponseEntity
+                .status(errorCode.getHttpStatus())
+                .body(ErrorResponse.builder()
+                        .statusCode(errorCode.getHttpStatus().value())
+                        .statusCodeName(errorCode.getHttpStatus().name())
+                        .code(errorCode.name())
+                        .message(errorCode.getMessage())
+                        .runtimeValue(runtimeValue)
+                        .build()
+                );
+    }
+}

--- a/src/main/java/com/example/baro/common/exception/dto/ValidationErrorResponse.java
+++ b/src/main/java/com/example/baro/common/exception/dto/ValidationErrorResponse.java
@@ -1,0 +1,13 @@
+package com.example.baro.common.exception.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class ValidationErrorResponse {
+
+    private String field;
+    private String message;
+    private Object rejectedValue;
+}

--- a/src/main/java/com/example/baro/common/exception/exceptionClass/CustomException.java
+++ b/src/main/java/com/example/baro/common/exception/exceptionClass/CustomException.java
@@ -1,0 +1,20 @@
+package com.example.baro.common.exception.exceptionClass;
+
+import com.example.baro.common.exception.properties.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+    private final String runtimeValue;
+
+    public CustomException(ErrorCode errorCode) {
+        this(errorCode, "runtimeValue가 존재 하지 않습니다.");
+    }
+
+    public CustomException(ErrorCode errorCode, String runtimeValue) {
+        this.errorCode = errorCode;
+        this.runtimeValue = runtimeValue;
+    }
+}

--- a/src/main/java/com/example/baro/common/exception/properties/ErrorCode.java
+++ b/src/main/java/com/example/baro/common/exception/properties/ErrorCode.java
@@ -1,0 +1,40 @@
+package com.example.baro.common.exception.properties;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.*;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+
+    // 400
+    REFRESH_TOKEN_REQUIRED(BAD_REQUEST, "refresh token이 필요합니다."),
+    PHOTO_NETWORK_ERROR(BAD_REQUEST, "스토리지에 사진을 저장하는 데 실패했습니다."),
+    SOCIAL_INFO_NOT_EXTRACTED(BAD_REQUEST, "이메일을 추출할 수 없습니다."),
+    ADMIN_PASSWORD_INCORRECT(BAD_REQUEST, "잘못된 비밀번호입니다."),
+
+    // 401
+    SECURITY_UNAUTHORIZED(UNAUTHORIZED, "인증 정보가 유효하지 않습니다"),
+    SECURITY_INVALID_TOKEN(UNAUTHORIZED, "토큰이 유효하지 않습니다."),
+    SECURITY_INVALID_REFRESH_TOKEN(UNAUTHORIZED, "refresh token이 유효하지 않습니다."),
+    SECURITY_INVALID_ACCESS_TOKEN(UNAUTHORIZED, "access token이 유효하지 않습니다."),
+
+    // 403
+    SECURITY_ACCESS_DENIED(FORBIDDEN, "접근 권한이 없습니다."),
+
+    // 404
+    USER_NOT_FOUND(NOT_FOUND, "user을 찾을 수 없습니다."),
+    REVIEW_NOT_FOUND(NOT_FOUND, "review를 찾을 수 없습니다."),
+
+    // 409
+    DATE_FORMAT_CONFLICT(CONFLICT, "날짜 형식이 올바르지 않습니다."),
+
+    // 500
+    SERVER_ERROR(INTERNAL_SERVER_ERROR, "예상치 못한 서버 에러가 발생하였습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}


### PR DESCRIPTION

1. GlobalExceptionHandler
애플리케이션 실행 중 다양한 이유(잘못된 입력, 서버 오류 등)로 예외가 발생합니다.
예외의 종류에 따라 Spring의 @RestControllerAdvice가 해당 예외를 처리하기 위해 준비된 핸들러 메서드를 실행합니다.

2. ErrorResponse
정의된 ErrorCode와 runtimeValue를 반환합니다.

3. ValidationErrorREsponse
실패한 필드별 에러 메시지와 세부 정보를 리스트 형태로 반환합니다.

4. CustomException
RuntimeExcpeion을 상속받았습니다. 

5. ErrorCode
에러메시지를 담고 있는 enum입니다. 