### PR TITLE
Feat: 약속 제안서 세션기능 빼고 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,8 @@ out/
 
 ### VS Code ###
 .vscode/
+
+# H2 Database Files
+/data/*.db
+/data/*.mv.db
+/data/*.trace.db

--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,8 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    runtimeOnly 'com.h2database:h2'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/baro/common/exception/properties/ErrorCode.java
+++ b/src/main/java/com/example/baro/common/exception/properties/ErrorCode.java
@@ -29,6 +29,7 @@ public enum ErrorCode {
     USER_NOT_FOUND(NOT_FOUND, "user을 찾을 수 없습니다."),
     REVIEW_NOT_FOUND(NOT_FOUND, "review를 찾을 수 없습니다."),
     SCHEDULE_NOT_FOUND(NOT_FOUND, "schedule을 찾을 수 없습니다."),
+    PROMISE_NOT_FOUND(NOT_FOUND, "promise를 찾을 수 없습니다. "),
 
     // 409
     DATE_FORMAT_CONFLICT(CONFLICT, "날짜 형식이 올바르지 않습니다."),

--- a/src/main/java/com/example/baro/domain/promise/controller/PromiseController.java
+++ b/src/main/java/com/example/baro/domain/promise/controller/PromiseController.java
@@ -1,0 +1,50 @@
+package com.example.baro.domain.promise.controller;
+
+import com.example.baro.domain.promise.dto.PromiseSuggestRequest;
+import com.example.baro.domain.promise.dto.PromiseSuggestResponse;
+import com.example.baro.domain.promise.service.PromiseService;
+import lombok.RequiredArgsConstructor;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Promise", description = "약속 제안서 관련 API. 토큰이 필요합니다.")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/promise")
+public class PromiseController {
+
+    private final PromiseService promiseService;
+
+    @Operation(
+            summary = "약속 제안서 등록",
+            description = "약속 제안서를 등록합니다. "
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "약속 제안서 등록에 성공하였습니다."
+    )
+    @PostMapping("/suggest")
+    public ResponseEntity<PromiseSuggestResponse> registerPromise(
+            @RequestBody PromiseSuggestRequest request) {
+
+        PromiseSuggestResponse response = promiseService.registerPromise(request);
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(
+            summary = "약속 제안서 삭제",
+            description = "약속 제안서를 삭제합니다. "
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "약속 제안서 삭제에 성공하였습니다."
+    )
+    @DeleteMapping("/suggest/{promiseId}")
+    public ResponseEntity<Void> deletePromise(@PathVariable Long promiseId) {
+        promiseService.deletePromise(promiseId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/example/baro/domain/promise/dto/PromiseSuggestRequest.java
+++ b/src/main/java/com/example/baro/domain/promise/dto/PromiseSuggestRequest.java
@@ -1,0 +1,12 @@
+package com.example.baro.domain.promise.dto;
+
+import lombok.Getter;
+
+@Getter
+public class PromiseSuggestRequest {
+    private String name;
+    private String dateStart;
+    private String dateEnd;
+    private int peopleNum;
+    private String purpose;
+}

--- a/src/main/java/com/example/baro/domain/promise/dto/PromiseSuggestResponse.java
+++ b/src/main/java/com/example/baro/domain/promise/dto/PromiseSuggestResponse.java
@@ -1,0 +1,29 @@
+package com.example.baro.domain.promise.dto;
+
+import com.example.baro.domain.promise.entity.Promise;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+public class PromiseSuggestResponse {
+    private String name;
+    // private String userName;
+    // private String placeName;
+    private LocalDate dateStart;
+    private LocalDate dateEnd;
+    private int peopleNum;
+    private String purpose;
+
+    public static PromiseSuggestResponse from(Promise promise) {
+        return PromiseSuggestResponse.builder()
+                .name(promise.getName())
+                .dateStart(promise.getDate_start())
+                .dateEnd(promise.getDate_end())
+                .peopleNum(promise.getPeopleNum())
+                .purpose(promise.getPurpose())
+                .build();
+    }
+}

--- a/src/main/java/com/example/baro/domain/promise/entity/Promise.java
+++ b/src/main/java/com/example/baro/domain/promise/entity/Promise.java
@@ -1,0 +1,76 @@
+package com.example.baro.domain.promise.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.sql.Time;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.Date;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "promise_TB")
+@Getter
+public class Promise {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = true)
+    private Long regionId;
+
+    @Column(nullable = true)
+    private Long placeId;
+
+    @Column(nullable = true)
+    private String status;
+
+    @CreationTimestamp
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(nullable = false)
+    private LocalDateTime updateAt;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private LocalDate date_start;
+
+    @Column(nullable = false)
+    private LocalDate date_end;
+
+    @Column(nullable = false)
+    private LocalTime time_start;
+
+    @Column(nullable = false)
+    private LocalTime time_end;
+
+    @Column(nullable = false)
+    private int peopleNum;
+
+    @Column(nullable = false)
+    private String purpose;
+
+    @Builder
+    public Promise(String name, Date date, LocalDate date_start, LocalDate date_end,
+                   LocalTime time_start, LocalTime time_end, int peopleNum, String purpose) {
+        this.name = name;
+        this.date_start = date_start;
+        this.date_end = date_end;
+        this.time_start = time_start;
+        this.time_end = time_end;
+        this.peopleNum = peopleNum;
+        this.purpose = purpose;
+    }
+}

--- a/src/main/java/com/example/baro/domain/promise/exception/PromiseException.java
+++ b/src/main/java/com/example/baro/domain/promise/exception/PromiseException.java
@@ -1,0 +1,10 @@
+package com.example.baro.domain.promise.exception;
+
+import com.example.baro.common.exception.exceptionClass.CustomException;
+import com.example.baro.common.exception.properties.ErrorCode;
+
+public class PromiseException extends CustomException {
+    public PromiseException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/example/baro/domain/promise/repository/PromiseRepository.java
+++ b/src/main/java/com/example/baro/domain/promise/repository/PromiseRepository.java
@@ -1,0 +1,8 @@
+package com.example.baro.domain.promise.repository;
+
+import com.example.baro.domain.promise.entity.Promise;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PromiseRepository extends JpaRepository<Promise, Long> {
+
+}

--- a/src/main/java/com/example/baro/domain/promise/service/PromiseService.java
+++ b/src/main/java/com/example/baro/domain/promise/service/PromiseService.java
@@ -1,0 +1,48 @@
+package com.example.baro.domain.promise.service;
+
+import com.example.baro.common.exception.properties.ErrorCode;
+import com.example.baro.domain.promise.dto.PromiseSuggestRequest;
+import com.example.baro.domain.promise.dto.PromiseSuggestResponse;
+import com.example.baro.domain.promise.entity.Promise;
+import com.example.baro.domain.promise.exception.PromiseException;
+import com.example.baro.domain.promise.repository.PromiseRepository;
+import com.example.baro.domain.promise.util.DateParser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalTime;
+
+@RequiredArgsConstructor
+@Service
+@Transactional
+public class PromiseService {
+
+    private final PromiseRepository promiseRepository;
+    private final LocalTime defaultStartTime = LocalTime.of(9, 0);
+    private final LocalTime defaultEndTime = LocalTime.of(18, 0);
+
+    public PromiseSuggestResponse registerPromise(PromiseSuggestRequest request) {
+        Promise promise = Promise.builder()
+                .name(request.getName())
+                .date_start(DateParser.parseDate(request.getDateStart()))
+                .date_end(DateParser.parseDate(request.getDateEnd()))
+                .time_start(defaultStartTime)
+                .time_end(defaultEndTime)
+                .peopleNum(request.getPeopleNum())
+                .purpose(request.getPurpose())
+                .build();
+
+        promiseRepository.save(promise);
+
+        return PromiseSuggestResponse.from(promise);
+    }
+
+    public void deletePromise(Long promiseId) {
+        Promise promise = promiseRepository.findById(promiseId)
+                .orElseThrow(() -> new PromiseException(ErrorCode.PROMISE_NOT_FOUND));
+
+        promiseRepository.delete(promise);
+    }
+
+}

--- a/src/main/java/com/example/baro/domain/promise/util/DateParser.java
+++ b/src/main/java/com/example/baro/domain/promise/util/DateParser.java
@@ -1,0 +1,21 @@
+package com.example.baro.domain.promise.util;
+
+import com.example.baro.common.exception.properties.ErrorCode;
+import com.example.baro.domain.promise.exception.PromiseException;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+
+public class DateParser {
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+    public static LocalDate parseDate(String dateString) {
+
+        try {
+            return LocalDate.parse(dateString, FORMATTER);
+        } catch (DateTimeParseException e) {
+            throw new PromiseException(ErrorCode.DATE_FORMAT_CONFLICT);
+        }
+    }
+}

--- a/src/main/java/com/example/baro/domain/schedule/contoller/ScheduleController.java
+++ b/src/main/java/com/example/baro/domain/schedule/contoller/ScheduleController.java
@@ -1,4 +1,0 @@
-package com.example.baro.domain.schedule.contoller;
-
-public class ScheduleController {
-}

--- a/src/main/java/com/example/baro/domain/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/example/baro/domain/schedule/controller/ScheduleController.java
@@ -1,0 +1,4 @@
+package com.example.baro.domain.schedule.controller;
+
+public class ScheduleController {
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,15 @@
 spring.application.name=BARO
+
+# H2 ??
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.url=jdbc:h2:file:./data/demo
+spring.datasource.username=sa
+spring.datasource.password=
+
+# JPA ??
+spring.jpa.hibernate.ddl-auto=create
+spring.jpa.show-sql=true
+
+# H2 ??
+spring.h2.console.enabled=true
+spring.h2.console.path=/h2-console


### PR DESCRIPTION
말그대로 세션기능을 뺀

약속 제안서 생성과 삭제 기능을 완료했습니다. 

그리고 Promise 도메인에 관한 entity나 controller도 구현했으니 참고바랍니다. 