### PR TITLE
Feat/#70: PromisePersonal 구현(약속 수락 - 시간/키워드/장소 & 약속 거절)

### DIFF
--- a/src/main/java/com/example/baro/domain/promise/controller/PromisePersonalController.java
+++ b/src/main/java/com/example/baro/domain/promise/controller/PromisePersonalController.java
@@ -1,0 +1,48 @@
+package com.example.baro.domain.promise.controller;
+
+import com.example.baro.common.dto.ApiResponseDto;
+import com.example.baro.common.dto.enums.SuccessCode;
+import com.example.baro.common.entity.User;
+import com.example.baro.common.resolver.LoginUser;
+import com.example.baro.domain.place.dto.request.ReviewPostRequestDto;
+import com.example.baro.domain.promise.dto.request.PromisePersonalKeywordRequestDto;
+import com.example.baro.domain.promise.dto.request.PromisePersonalPlaceRequestDto;
+import com.example.baro.domain.promise.dto.request.PromisePersonalTimeRequestDto;
+import com.example.baro.domain.promise.service.PromisePersonalService;
+import jakarta.validation.Valid;
+import lombok.AllArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@AllArgsConstructor
+@RestController
+@RequestMapping("/promise/personal")
+public class PromisePersonalController{
+    private final PromisePersonalService promisePersonalService;
+
+    @PostMapping("/{promiseId}/times")
+    public ApiResponseDto setPersonalTimes(@Valid @RequestBody PromisePersonalTimeRequestDto requestDto, @LoginUser User user, @PathVariable Long promiseId) {
+        promisePersonalService.setPersonalTimes(requestDto, user, promiseId);
+        return ApiResponseDto.success(SuccessCode.NOTE_CREATE_SUCCESS);
+    }
+
+
+    @PostMapping("/{promiseId}/keywords")
+    public ApiResponseDto setPersonalKeywords(@Valid @RequestBody PromisePersonalKeywordRequestDto requestDto, @LoginUser User user, @PathVariable Long promiseId) {
+        promisePersonalService.setPersonalKeywords(requestDto, user, promiseId);
+        return ApiResponseDto.success(SuccessCode.NOTE_CREATE_SUCCESS);
+    }
+
+    @PostMapping("/{promiseId}/places")
+    public ApiResponseDto setPersonalPlaces(@Valid @RequestBody PromisePersonalPlaceRequestDto requestDto, @LoginUser User user, @PathVariable Long promiseId) {
+        promisePersonalService.setPersonalPlaces(requestDto, user, promiseId);
+        return ApiResponseDto.success(SuccessCode.NOTE_CREATE_SUCCESS);
+    }
+
+    @PostMapping("/{promiseId}/reject")
+    public ApiResponseDto rejectPersonal(@LoginUser User user, @PathVariable Long promiseId) {
+        promisePersonalService.rejectPersonal(user, promiseId);
+        return ApiResponseDto.success(SuccessCode.NOTE_CREATE_SUCCESS);
+    }
+
+
+}

--- a/src/main/java/com/example/baro/domain/promise/dto/request/PromisePersonalKeywordRequestDto.java
+++ b/src/main/java/com/example/baro/domain/promise/dto/request/PromisePersonalKeywordRequestDto.java
@@ -1,0 +1,16 @@
+package com.example.baro.domain.promise.dto.request;
+
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+public record PromisePersonalKeywordRequestDto(
+        @NotNull(message = "keywordIds는 필수 입력값입니다.")
+        @Size(min = 1, message = "최소 하나 이상의 키워드를 입력해야 합니다.")
+        List<Long> keywordIds
+) {
+}

--- a/src/main/java/com/example/baro/domain/promise/dto/request/PromisePersonalPlaceRequestDto.java
+++ b/src/main/java/com/example/baro/domain/promise/dto/request/PromisePersonalPlaceRequestDto.java
@@ -1,0 +1,14 @@
+package com.example.baro.domain.promise.dto.request;
+
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+
+public record PromisePersonalPlaceRequestDto(
+        @NotNull(message = "placeIds는 필수 입력값입니다.")
+        @Size(min = 1, message = "최소 하나 이상의 장소를 입력해야 합니다.")
+        List<Long> placeIds
+) {
+}

--- a/src/main/java/com/example/baro/domain/promise/dto/request/PromisePersonalTimeRequestDto.java
+++ b/src/main/java/com/example/baro/domain/promise/dto/request/PromisePersonalTimeRequestDto.java
@@ -1,0 +1,20 @@
+package com.example.baro.domain.promise.dto.request;
+
+
+import jakarta.validation.constraints.*;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+public record PromisePersonalTimeRequestDto(
+        @NotNull(message = "times는 필수 입력값입니다.")
+        @Size(min = 1, message = "최소 하나 이상의 시간을 입력해야 합니다.")
+        List<TimeDto> times
+) {
+    public record TimeDto(
+            LocalDate date,
+            LocalTime time_start,
+            LocalTime time_end
+    ) {}
+}

--- a/src/main/java/com/example/baro/domain/promise/repository/PromisePersonalKeywordRepository.java
+++ b/src/main/java/com/example/baro/domain/promise/repository/PromisePersonalKeywordRepository.java
@@ -1,0 +1,24 @@
+package com.example.baro.domain.promise.repository;
+
+import com.example.baro.common.entity.Keyword;
+import com.example.baro.common.entity.PromisePersonalKeyword;
+import com.example.baro.common.entity.PromisePersonalKeywordId;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface PromisePersonalKeywordRepository extends JpaRepository<PromisePersonalKeyword, PromisePersonalKeywordId>{
+	@Query("SELECT sk.keyword FROM SearchKeyword sk " +
+			"JOIN sk.search s " +
+			"WHERE s.user.id = :userId")
+	List<Keyword> findKeywordsByUserId(@Param("userId") Long userId);
+
+	@Query("SELECT sk.keyword FROM Search s " +
+			"JOIN SearchKeyword sk ON sk.search.id = s.id " +
+			"WHERE s.id = :searchId")
+	List<Keyword> findKeywordsBySearchId(@Param("searchId") Long searchId);
+}

--- a/src/main/java/com/example/baro/domain/promise/service/PromisePersonalService.java
+++ b/src/main/java/com/example/baro/domain/promise/service/PromisePersonalService.java
@@ -1,0 +1,104 @@
+package com.example.baro.domain.promise.service;
+
+
+import com.example.baro.common.Enum.status.Status;
+import com.example.baro.common.entity.*;
+import com.example.baro.common.exception.exceptionClass.InvalidRequestException;
+import com.example.baro.domain.keyword.repository.KeywordRepository;
+import com.example.baro.domain.place.repository.PlaceRepository;
+import com.example.baro.domain.promise.dto.request.PromisePersonalKeywordRequestDto;
+import com.example.baro.domain.promise.dto.request.PromisePersonalPlaceRequestDto;
+import com.example.baro.domain.promise.dto.request.PromisePersonalTimeRequestDto;
+import com.example.baro.domain.promise.repository.PromisePersonalKeywordRepository;
+import com.example.baro.domain.promise.repository.PromisePersonalPlaceRepository;
+import com.example.baro.domain.promise.repository.PromisePersonalTimeRepository;
+import com.example.baro.domain.user.repository.PromisePersonalRepository;
+import jakarta.transaction.Transactional;
+import jakarta.validation.Valid;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+
+
+@AllArgsConstructor
+@Service
+@Transactional
+public class PromisePersonalService {
+    final private PromisePersonalTimeRepository promisePersonalTimeRepository;
+    final private PromisePersonalRepository promisePersonalRepository;
+    final private PromisePersonalKeywordRepository promisePersonalKeywordRepository;
+    final private KeywordRepository keywordRepository;
+    final private PromisePersonalPlaceRepository promisePersonalPlaceRepository;
+    final private PlaceRepository placeRepository;
+
+
+    public void setPersonalTimes(@Valid PromisePersonalTimeRequestDto requestDto, User user, Long promiseId) {
+        PromisePersonal promisePersonal = getPromisePersonal(user, promiseId);
+
+        // PromisePersonalTime(개인 시간) 세팅
+        for (PromisePersonalTimeRequestDto.TimeDto slot : requestDto.times()) {
+            PromisePersonalTime timeSlot = PromisePersonalTime.builder()
+                    .promisePersonal(promisePersonal)
+                    .date(slot.date())  // LocalDate 자동 변환됨
+                    .timeStart(slot.time_start())  // LocalTime 자동 변환됨
+                    .timeEnd(slot.time_end())  // LocalTime 자동 변환됨
+                    .build();
+
+            promisePersonalTimeRepository.save(timeSlot);
+        }
+    }
+
+    public void setPersonalKeywords(@Valid PromisePersonalKeywordRequestDto requestDto, User user, Long promiseId) {
+        PromisePersonal promisePersonal = getPromisePersonal(user, promiseId);
+
+        for (Long keywordId : requestDto.keywordIds()){
+            // id로 키워드 가져오기
+            Keyword keyword = keywordRepository
+                    .findById(keywordId)
+                    .orElseThrow(() -> new InvalidRequestException("잘못된 keywordId입니다. :  " + keywordId));
+
+            // PromisePersonalKeyword(개인 키워드) 세팅
+            PromisePersonalKeyword promisePersonalKeyword = PromisePersonalKeyword.builder()
+                    .keyword(keyword)
+                    .promisePersonal(promisePersonal)
+                    .build();
+
+            promisePersonalKeywordRepository.save(promisePersonalKeyword);
+
+        }
+
+    }
+
+    public void setPersonalPlaces(@Valid PromisePersonalPlaceRequestDto requestDto, User user, Long promiseId) {
+        PromisePersonal promisePersonal = getPromisePersonal(user, promiseId);
+
+        for (Long placeId : requestDto.placeIds()){
+            // id로 장소 가져오기
+            Place place = placeRepository
+                    .findById(placeId)
+                    .orElseThrow(() -> new InvalidRequestException("잘못된 placeId입니다. :  " + placeId));
+
+            // PromisePersonalPlace(개인 장소) 세팅
+            PromisePersonalPlace promisePersonalplace = PromisePersonalPlace.builder()
+                    .place(place)
+                    .promisePersonal(promisePersonal)
+                    .build();
+
+            promisePersonalPlaceRepository.save(promisePersonalplace);
+
+        }
+
+        promisePersonal.setStatus(Status.ACTIVE);
+    }
+
+    public void rejectPersonal(User user, Long promiseId) {
+        PromisePersonal promisePersonal = getPromisePersonal(user, promiseId);
+        promisePersonal.setStatus(Status.SUSPENDED);
+    }
+
+    private PromisePersonal getPromisePersonal(User user, Long promiseId) {
+        PromisePersonal promisePersonal = promisePersonalRepository
+                .findByIdAAndUser(promiseId, user)
+                .orElseThrow(() -> new InvalidRequestException("잘못된 promiseId입니다. :  " + promiseId));
+        return promisePersonal;
+    }
+}

--- a/src/main/java/com/example/baro/domain/user/repository/PromisePersonalRepository.java
+++ b/src/main/java/com/example/baro/domain/user/repository/PromisePersonalRepository.java
@@ -9,10 +9,13 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface PromisePersonalRepository extends JpaRepository<PromisePersonal, Long> {
 	List<PromisePersonal> findAllByUser(User user);
+
+	Optional<PromisePersonal> findByIdAAndUser(Long aLong, User user);
 
 	List<PromisePersonal> findAllByUserAndStatus(User user, Status status);
 


### PR DESCRIPTION
## 📌 관련 이슈
#70

## ✨ 과제 내용
API 명세서 바탕으로 개인약속 수락 & 거절 구현

약속 생성 promise(ACTIVE), promisePersonal(INACTIVE) 둘다 생성되는 것을 바탕으로 다음과 같이 구현
약속 거절 promisePersonal => SUSPEND
약속 수락(장소) promisePersonal(INACTIVE => ACTIVE)

약속 수락

1) 시간
- user, promiseId => promisePersonal 가져오기
- PromisePersonalTime을 requestDto로 반영
2) 키워드
- user, promiseId => promisePersonal 가져오기
- PromisePersonalKeyword를 requestDto로 반영
  - id로 키워드 가져오기
  - PromisePersonalKeyword반영
3) 장소
- user, promiseId => promisePersonal 가져오기
- PromisePersonalKeyword를 requestDto로 반영
  - id로 장소 가져오기
  - PromisePersonalPlace반영
- promisePersonal의 status를 ACTIVE로 변경

약속 거절
- user, promiseId => promisePersonal 가져오기
- promisePersonal의 status를 SUSPENDED로 변경