### PR TITLE
Fix/#75: PromiseVote & /{promiseId}/reject

### DIFF
--- a/src/main/java/com/example/baro/common/entity/PromiseVote.java
+++ b/src/main/java/com/example/baro/common/entity/PromiseVote.java
@@ -30,11 +30,14 @@ public class PromiseVote {
     private Promise promise;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "promis_personal_time_id", nullable = false)
+    @JoinColumn(name = "promise_personal_time_id", nullable = false)
     private PromisePersonalTime promisePersonalTime;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "promise_personal_place_id", nullable = false)
+    @JoinColumns({
+            @JoinColumn(name = "promise_personal_id", referencedColumnName = "promise_personal_id"),
+            @JoinColumn(name = "place_id", referencedColumnName = "place_id")
+    })
     private PromisePersonalPlace promisePersonalPlace;
 
     @Builder

--- a/src/main/java/com/example/baro/domain/promise/controller/PromisePersonalController.java
+++ b/src/main/java/com/example/baro/domain/promise/controller/PromisePersonalController.java
@@ -38,7 +38,7 @@ public class PromisePersonalController{
         return ApiResponseDto.success(SuccessCode.NOTE_CREATE_SUCCESS);
     }
 
-    @PostMapping("/{promiseId}/reject")
+    @PatchMapping("/{promiseId}/reject")
     public ApiResponseDto rejectPersonal(@LoginUser User user, @PathVariable Long promiseId) {
         promisePersonalService.rejectPersonal(user, promiseId);
         return ApiResponseDto.success(SuccessCode.NOTE_CREATE_SUCCESS);

--- a/src/main/java/com/example/baro/domain/promise/service/PromisePersonalService.java
+++ b/src/main/java/com/example/baro/domain/promise/service/PromisePersonalService.java
@@ -97,7 +97,7 @@ public class PromisePersonalService {
 
     private PromisePersonal getPromisePersonal(User user, Long promiseId) {
         PromisePersonal promisePersonal = promisePersonalRepository
-                .findByIdAAndUser(promiseId, user)
+                .findByIdAndUser(promiseId, user)
                 .orElseThrow(() -> new InvalidRequestException("잘못된 promiseId입니다. :  " + promiseId));
         return promisePersonal;
     }

--- a/src/main/java/com/example/baro/domain/user/repository/PromisePersonalRepository.java
+++ b/src/main/java/com/example/baro/domain/user/repository/PromisePersonalRepository.java
@@ -15,7 +15,7 @@ import java.util.Optional;
 public interface PromisePersonalRepository extends JpaRepository<PromisePersonal, Long> {
 	List<PromisePersonal> findAllByUser(User user);
 
-	Optional<PromisePersonal> findByIdAAndUser(Long aLong, User user);
+	Optional<PromisePersonal> findByIdAndUser(Long aLong, User user);
 
 	List<PromisePersonal> findAllByUserAndStatus(User user, Status status);
 


### PR DESCRIPTION
## 📌 관련 이슈
#75
## ✨ 과제 내용
PromiseVote가 PromisePersonalPlace를 복합키로 참조하지 않고 있는 문제 해결
/{promiseId}/reject를 POST에서 PATCH로 바꾸기
